### PR TITLE
Updated clarity in wording about token limits

### DIFF
--- a/src/handlers/config.ts
+++ b/src/handlers/config.ts
@@ -17,13 +17,13 @@ const configHandler = async () => {
     },
     {
       message:
-        'How many tokens you want as a limit? More info here https://openai.com/api/pricing/',
+        'Daily budget spend on tokens for AskGPT? See https://openai.com/api/pricing/ for more info',
       type: 'number',
       name: 'tokens'
     },
     {
       message:
-        'Which model do you want to use? (Davinci is the most powerful but costs more, Ada is the fastest and cheapest model but is not as powerful). More info here https://beta.openai.com/docs/models/overview',
+        'Which model do you want to use? (Davinci is the most powerful but costs more, Ada is the fastest and cheapest model but is not as powerful). More info here https://platform.openai.com/docs/models/overview',
       type: 'list',
       name: 'model',
       choices: [


### PR DESCRIPTION
I've simply changed the message asked when the user is asked for their token limit to provide more clarity as to what kind of information we want from the user. 

Prevents errors coming up like:

```
Introduce your OpenAI API key: 
// my config key
? How many tokens you want as a limit? More info here https://openai.com/api/pricing:
```
Me proceeding to calculate the exact amount of tokens I'd like to use as my limit* 
Tries that number, makes a message:

```
? What do you want to ask? 
Asking GPT... How can an AI text generator provide insights into areas of medicine and law that are difficult for humans to comprehend?
OpenAI API error:
{
  error: {
    message: 'Rate limit reached for default-text-davinci-003 in {/*my-organisation-id*/} on tokens per min. Limit: 250000.000000 / min. Current: 25000000.000000 / min. Contact support@openai.com if you continue to have issues.',
    type: 'tokens',
    param: null,
    code: null
  }
}
```

And receiving something like that ^